### PR TITLE
fix: correct sucessfully→successfully typo in boot/functions.zsh

### DIFF
--- a/boot/functions.zsh
+++ b/boot/functions.zsh
@@ -124,7 +124,7 @@ ningrab() {
         return $rc
       fi
     fi
-    echo -e "[${Green}${name}${Rst}] sucessfully cloned."
+    echo -e "[${Green}${name}${Rst}] successfully cloned."
   fi
   echo -e "-------------------"
 }


### PR DESCRIPTION
Fix typo in git clone success message (line 127): `sucessfully` → `successfully`

1 file, 1 line change.